### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 
 name: godot-mono
-version: '3.0.4'
+version: '3.0.6'
 summary: Godot Engine (Mono version) – Multi-platform 2D and 3D game engine
 description: |
   Godot Engine is a feature-packed, cross-platform game engine to
@@ -13,6 +13,10 @@ description: |
   This package contains the Mono version with (C# support)
 
 confinement: strict
+
+architectures:
+  - build-on: i386
+  - build-on: amd64
 
 apps:
   godot-mono:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,8 +37,8 @@ parts:
     after: [desktop-glib-only]
     plugin: dump
     source:
-      - on amd64: https://downloads.tuxfamily.org/godotengine/3.0.4/mono/Godot_v$SNAPCRAFT_PROJECT_VERSION-stable_mono_x11_64.zip
-      - on i386: https://downloads.tuxfamily.org/godotengine/3.0.4/mono/Godot_v$SNAPCRAFT_PROJECT_VERSION-stable_mono_x11_32.zip
+      - on amd64: https://downloads.tuxfamily.org/godotengine/$SNAPCRAFT_PROJECT_VERSION/mono/Godot_v$SNAPCRAFT_PROJECT_VERSION-stable_mono_x11_64.zip
+      - on i386: https://downloads.tuxfamily.org/godotengine/$SNAPCRAFT_PROJECT_VERSION/mono/Godot_v$SNAPCRAFT_PROJECT_VERSION-stable_mono_x11_32.zip
     stage-packages:
       - libgl1-mesa-dri
       - libglu1-mesa


### PR DESCRIPTION
Ensure we don't waste build time on the builders, by only trying to build on amd64 and i386.